### PR TITLE
Changes in db now reflects on Page

### DIFF
--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -115,7 +115,14 @@ function DirectoryContent() {
         searchParams.getAll('skills').forEach(skill => {
           queryParams.append('skills', skill);
         });
-        const response = await fetch(`/api/directory/search?${queryParams.toString()}`);
+        queryParams.append('_t', Date.now().toString());
+        const response = await fetch(`/api/directory/search?${queryParams.toString()}`, {
+        cache: 'no-store',
+          headers: {
+          'Cache-Control': 'no-cache',
+          'Pragma': 'no-cache'
+          }
+        });
         const data = await response.json();
         if (!response.ok) {
           throw new Error(data.message || 'Failed to fetch members');


### PR DESCRIPTION
Updated the way we fetch data from /api/directory/search.
Added a timestamp to the URL and set no-cache headers,this forces the browser to always fetch fresh data from the server.

Before this any changes made in DB reflected only inside profile page and not on the directory cards, which is now fixed