### PR TITLE
Fixed email id in footer

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -57,13 +57,7 @@ export function Footer() {
                 Directory
               </Link>
               <Link
-                href="/upload"
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Upload Resume
-              </Link>
-              <Link
-                href="/auth/sign-in"
+                href="/auth/email-link-sign-in"
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 Sign In
@@ -113,11 +107,11 @@ export function Footer() {
             <h3 className="text-sm font-semibold">Contact</h3>
             <div className="flex flex-col gap-2">
               <Link
-                href="mailto:contact@pointblank.club"
+                href="mailto:careers@pointblank.club"
                 className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 <Mail className="h-4 w-4" />
-                contact@pointblank.club
+                careers@pointblank.club
               </Link>
               <p className="text-sm text-muted-foreground">
                 Have questions? We&apos;re here to help.

--- a/components/profile/export-profile-button.tsx
+++ b/components/profile/export-profile-button.tsx
@@ -51,14 +51,12 @@ export function ExportProfileButton({ memberId, memberName, memberEmail }: Expor
       throw new Error(data.message || 'Failed to generate resume download');
     }
 
-    // Trigger browser download
+    const fileRes = await fetch(data.resumeUrl);
+    const blob = await fileRes.blob();
     const link = document.createElement('a');
-    link.href = data.resumeUrl;
-    link.setAttribute('download', data.filename);
-    link.setAttribute('target', '_blank'); // Optional: open in new tab if not download
-    document.body.appendChild(link);
+    link.href = URL.createObjectURL(blob);
+    link.download = data.filename;
     link.click();
-    document.body.removeChild(link);
   } catch (err) {
     console.error('Resume download failed:', err);
     alert('Failed to download resume.');
@@ -217,7 +215,7 @@ try {
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleExportPDF}>
               <Download className="h-4 w-4 mr-2" />
-              Export as PDF
+              Download PDF
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleShareProfile}>

--- a/components/profile/resume-section.tsx
+++ b/components/profile/resume-section.tsx
@@ -90,12 +90,17 @@ function ResumeModal({ resumeUrl, fileName, displayName }: {
                 variant="outline"
                 size="sm"
                 className="h-8 ml-4"
-                asChild
+                onClick={async () => {
+                  const blob = await (await fetch(resumeUrl)).blob();
+                  const link = Object.assign(document.createElement("a"), {
+                    href: URL.createObjectURL(blob),
+                    download: displayName,
+                  });
+                  link.click();
+                }}
               >
-                <a href={resumeUrl} download={displayName}>
-                  <Download className="h-3 w-3 mr-1" />
-                  Download
-                </a>
+                <Download className="h-3 w-3 mr-1" />
+                Download
               </Button>
             </div>
           </DialogHeader>


### PR DESCRIPTION
## Summary:  What does this PR do?

In https://github.com/pbdsce/pb-placements/pull/72/commits/0bd497b1c20d3a1d4d91b171a6e7e50804d3e49b commit,
-> Updated the email id from contact@pointblank.club to careers@pointblank.club in the footer.
-> Corrected the href of  Sign In in the footer

<img width="1920" height="1020" alt="Screenshot 2025-08-25 094431" src="https://github.com/user-attachments/assets/e1a26bf2-3832-4f5b-95c6-45d5c9bad7f5" />


In https://github.com/pbdsce/pb-placements/pull/72/commits/e9f09687e0665d169d0b1c4415ba834e68f3ae14 commit,
-> Added force download for the view popup (before: it was again redirecting to default pdf viewer)
-> Same thing even for export as pdf and altered that option to download pdf


https://github.com/user-attachments/assets/6fca0fdb-6aea-423c-a94c-9a479bf57b04



