### PR TITLE
Fix footer and remove last updated date of resume for other users

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -5,8 +5,8 @@ import Logo from "../ui/logo";
 export function Footer() {
   return (
     <footer className="border-t bg-background/95">
-      <div className="px-8 py-12 md:py-16 w-screen-md">
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-3 w-full">
+      <div className="max-w-7xl mx-auto px-8 py-12 md:py-16">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
           {/* Brand Section */}
           <div className="flex flex-col gap-4">
             <div className="shrink-0 mr-4">
@@ -47,7 +47,7 @@ export function Footer() {
           </div>
 
           {/* Quick Links */}
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 md:justify-self-center">
             <h3 className="text-sm font-semibold">Quick Links</h3>
             <nav className="flex flex-col gap-2">
               <Link
@@ -103,7 +103,7 @@ export function Footer() {
           </div> */}
 
           {/* Contact */}
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 md:justify-self-end">
             <h3 className="text-sm font-semibold">Contact</h3>
             <div className="flex flex-col gap-2">
               <Link

--- a/components/profile/resume-section.tsx
+++ b/components/profile/resume-section.tsx
@@ -370,9 +370,6 @@ export function ResumeSection({ resumeUrl, isEditable, userId, displayFileName }
           <FileText className="h-6 w-6 text-muted-foreground" />
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium truncate">{displayFileName || 'Resume.pdf'}</p>
-            <p className="text-xs text-muted-foreground truncate">
-              Last updated: {new Date().toISOString().slice(0, 10)}
-            </p>
           </div>
           <ResumeModal 
             resumeUrl={proxyUrl} 


### PR DESCRIPTION
This pr aligns the footer and removes the last updated date of resume for other users.
<img width="959" height="457" alt="Screenshot 2026-06-25 223156" src="https://github.com/user-attachments/assets/66cfe1a0-990c-4335-8a43-3e19f51e47dc" />
<img width="957" height="460" alt="Screenshot 2026-06-25 223125" src="https://github.com/user-attachments/assets/b2abe396-fc5b-46d6-a033-1923ab3f362a" />
