### PR TITLE
fix: prevent AI achievement hallucination and hide empty achievements tab for visitors

### DIFF
--- a/app/profile/[id]/page.tsx
+++ b/app/profile/[id]/page.tsx
@@ -122,6 +122,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   
   const isCurrentUser = user?.id === member.id;
   const displayFileName = formatResumeDisplayName(member.name, member.year_of_study);
+  const showAchievementsTab = achievements.length > 0 || isCurrentUser;
   
   return (
     <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-black relative overflow-hidden">
@@ -226,19 +227,21 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
             <div className="group transform hover:scale-[1.02] transition-all duration-500">
               <div className="bg-black rounded-2xl border border-gray-800 shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden">
                 <Tabs defaultValue="experience" className="w-full">
-                  <TabsList className="grid w-full grid-cols-2 bg-black rounded-t-xl p-0">
+                  <TabsList className={`grid w-full ${showAchievementsTab ? 'grid-cols-2' : 'grid-cols-1'} bg-black rounded-t-xl p-0`}>
                     <TabsTrigger 
                       value="experience" 
-                      className="data-[state=active]:bg-gray-800 data-[state=active]:text-green-400 rounded-tl-lg py-4 border-r border-gray-800"
+                      className={`data-[state=active]:bg-gray-800 data-[state=active]:text-green-400 py-4 ${showAchievementsTab ? 'rounded-tl-lg border-r border-gray-800' : 'rounded-t-lg'}`}
                     >
                       Experience
                     </TabsTrigger>
-                    <TabsTrigger 
-                      value="achievements" 
-                      className="data-[state=active]:bg-gray-800 data-[state=active]:text-green-400 rounded-tr-lg py-4"
-                    >
-                      Achievements
-                    </TabsTrigger>
+                    {showAchievementsTab && (
+                      <TabsTrigger 
+                        value="achievements" 
+                        className="data-[state=active]:bg-gray-800 data-[state=active]:text-green-400 rounded-tr-lg py-4"
+                      >
+                        Achievements
+                      </TabsTrigger>
+                    )}
                   </TabsList>
 
                   <div className="p-6">
@@ -257,20 +260,22 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                       </div>
                     </TabsContent>
 
-                    <TabsContent value="achievements">
-                      <div className="max-h-96 overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-gray-900">
-                        {achievements.length > 0 ? (
-                          <AchievementSection 
-                            achievements={achievements} 
-                            isEditable={isCurrentUser}
-                          />
-                        ) : (
-                          <div className="text-center text-gray-400 py-8">
-                            No achievements information available
-                          </div>
-                        )}
-                      </div>
-                    </TabsContent>
+                    {showAchievementsTab && (
+                      <TabsContent value="achievements">
+                        <div className="max-h-96 overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-gray-900">
+                          {achievements.length > 0 ? (
+                            <AchievementSection 
+                              achievements={achievements} 
+                              isEditable={isCurrentUser}
+                            />
+                          ) : (
+                            <div className="text-center text-gray-400 py-8">
+                              No achievements information available
+                            </div>
+                          )}
+                        </div>
+                      </TabsContent>
+                    )}
                   </div>
                 </Tabs>
               </div>

--- a/lib/resume-parser.ts
+++ b/lib/resume-parser.ts
@@ -278,7 +278,7 @@ export async function analyzeWithMistral(text: string, extractedLinks: string[] 
     3. A list of technical skills and technologies [Here First find the skills section from the resume. If its not present keep it empty]
     4. The primary domain/field analyse it effectively after analysing the skillset (e.g., Frontend Development,cybersecurity,backend development,devops,Data Science etc)
     5. Graduation year (YYYY format)
-    6. A list of notable achievements, take it from the achievements section of resume only. [Dont put any dates for achievements]
+    6. A list of notable achievements. ONLY extract from a section explicitly labeled "Achievements" or "Awards" in the resume. If no such section exists or no achievements are explicitly listed under it, return an empty array []. Do NOT extract from projects, experiences, or certifications sections. Do NOT infer, guess, or hallucinate achievements. [Dont put any dates for achievements]
     7. Work experiences take it from the experience section of the resume (including company name, role, description, start date, end date, and if it's current)
     8. Certifications take it from the certifications section of the resume (including certification name, issuing organization)
     9. Projects: take it from the projects section of the resume (including project name, description, and link if present)


### PR DESCRIPTION
## Summary:  What does this PR do?

Prevents the Mistral AI from hallucinating achievements and hides the Achievements tab from visitors when a user has none.

## Which issue(s) this PR fixes:

Fixes hallucinated achievements appearing on profiles from unrelated resume sections, and fixes the empty Achievements tab always showing to visitors even when there are no achievements.

## Changes Made
Describe the changes you've made in this PR:
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Configuration changes
- [ ] Other (please specify)

## Type of Change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## How Has This Been Tested?
Describe the tests you ran:
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please specify)

Please describe the test cases and expected behavior:
1. Upload resume with no Achievements section → AI returns [], tab hidden for visitors, only Experience tab shown full-width
2. Upload resume with a labeled Achievements/Awards section → achievements extracted correctly, tab visible to all

## Screenshots (if applicable)

Before 
<img width="1267" height="272" alt="image" src="https://github.com/user-attachments/assets/b26d1ed7-4f2f-4d71-a7e3-ca3bfdc6713f" />

After
<img width="1252" height="270" alt="image" src="https://github.com/user-attachments/assets/49b533ef-8f8a-40d6-aa30-51aff555e5a6" />


## Dependencies

## Documentation
- [ ] I have updated the documentation accordingly
- [x] Documentation update is not required

## Comments:

Two commits in this PR:
- `fix: restore original no-dates wording in achievement prompt` — tightened Mistral prompt in lib/resume-parser.ts to only extract from sections explicitly labeled "Achievements" or "Awards", returns [] otherwise. Prevents hallucination from projects/experience/certifications.
- `fix: prevent achievement hallucination and hide empty tab for non-owners` — app/profile/[id]/page.tsx now conditionally renders the Achievements tab only when achievements exist or viewer is the profile owner.

## Reviewer Notes

